### PR TITLE
Fix: Removed duplicate points from history function

### DIFF
--- a/src/repository.ts
+++ b/src/repository.ts
@@ -148,7 +148,7 @@ export class Repository<T> {
       [
         `SELECT *`,
         `FROM history(${this.config.tableName}) AS h`,
-        `WHERE h.${this.config.useMetadataKey ? 'metadata.' : 'data'}.${
+        `WHERE h.${this.config.useMetadataKey ? 'metadata' : 'data'}.${
           this.config.keyField
         } = ?`,
       ].join(' '),


### PR DESCRIPTION
There is a point, outside the conditional of this.config.useMetadataKey.

Causing duplicity in SELECT, querying for "metadata..id"